### PR TITLE
Standardize AimlApi integration

### DIFF
--- a/server/utils/AiProviders/aimlapi/index.js
+++ b/server/utils/AiProviders/aimlapi/index.js
@@ -10,6 +10,7 @@ const fs = require("fs");
 const path = require("path");
 const { safeJsonParse } = require("../../http");
 
+const AIMLAPI_BASE_URL = "https://api.aimlapi.com/v1";
 const AIMLAPI_HEADERS = {
   "HTTP-Referer": "https://anythingllm.com/",
   "X-Title": "anything",
@@ -28,7 +29,7 @@ class AimlApiLLM {
     const { OpenAI: OpenAIApi } = require("openai");
     this.openai = new OpenAIApi({
       apiKey: process.env.AIML_API_KEY,
-      baseURL: "https://api.aimlapi.com/v1",
+      baseURL: AIMLAPI_BASE_URL,
       defaultHeaders: AIMLAPI_HEADERS,
     });
     this.model =
@@ -39,14 +40,15 @@ class AimlApiLLM {
       user: this.promptWindowLimit() * 0.7,
     };
 
-    if (!fs.existsSync(cacheFolder)) fs.mkdirSync(cacheFolder, { recursive: true });
+    if (!fs.existsSync(cacheFolder))
+      fs.mkdirSync(cacheFolder, { recursive: true });
     this.cacheModelPath = path.resolve(cacheFolder, "models.json");
     this.cacheAtPath = path.resolve(cacheFolder, ".cached_at");
 
     this.embedder = embedder ?? new NativeEmbedder();
     this.defaultTemp = 0.7;
     this.log(
-      `Initialized ${this.model} with context window ${this.promptWindowLimit()}`,
+      `Initialized ${this.model} with context window ${this.promptWindowLimit()}`
     );
   }
 
@@ -67,7 +69,8 @@ class AimlApiLLM {
   }
 
   async #syncModels() {
-    if (fs.existsSync(this.cacheModelPath) && !this.#cacheIsStale()) return false;
+    if (fs.existsSync(this.cacheModelPath) && !this.#cacheIsStale())
+      return false;
     this.log("Model cache is not present or stale. Fetching from AimlApi API.");
     await fetchAimlApiModels();
     return;
@@ -220,7 +223,7 @@ class AimlApiLLM {
 
 async function fetchAimlApiModels(providedApiKey = null) {
   const apiKey = providedApiKey || process.env.AIML_API_KEY || null;
-  return await fetch(`https://api.aimlapi.com/v1/models`, {
+  return await fetch(`${AIMLAPI_BASE_URL}/models`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -237,7 +240,8 @@ async function fetchAimlApiModels(providedApiKey = null) {
           const developer =
             model.info?.developer ||
             model.provider ||
-            (model.id?.split("/")[0] || "AimlApi");
+            model.id?.split("/")[0] ||
+            "AimlApi";
           models[model.id] = {
             id: model.id,
             name: model.name || model.id,
@@ -269,7 +273,7 @@ async function fetchAimlApiModels(providedApiKey = null) {
 
 async function fetchAimlApiEmbeddingModels(providedApiKey = null) {
   const apiKey = providedApiKey || process.env.AIML_API_KEY || null;
-  return await fetch(`https://api.aimlapi.com/v1/models`, {
+  return await fetch(`${AIMLAPI_BASE_URL}/models`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -286,7 +290,8 @@ async function fetchAimlApiEmbeddingModels(providedApiKey = null) {
           const developer =
             model.info?.developer ||
             model.provider ||
-            (model.id?.split("/")[0] || "AimlApi");
+            model.id?.split("/")[0] ||
+            "AimlApi";
           models[model.id] = {
             id: model.id,
             name: model.name || model.id,
@@ -321,4 +326,5 @@ module.exports = {
   fetchAimlApiModels,
   fetchAimlApiEmbeddingModels,
   AIMLAPI_HEADERS,
+  AIMLAPI_BASE_URL,
 };

--- a/server/utils/EmbeddingEngines/aimlapi/index.js
+++ b/server/utils/EmbeddingEngines/aimlapi/index.js
@@ -1,5 +1,18 @@
 const { toChunks, maximumChunkLength } = require("../../helpers");
-const { AIMLAPI_HEADERS } = require("../../AiProviders/aimlapi");
+const {
+  AIMLAPI_HEADERS,
+  AIMLAPI_BASE_URL,
+  fetchAimlApiEmbeddingModels,
+} = require("../../AiProviders/aimlapi");
+const fs = require("fs");
+const path = require("path");
+const { safeJsonParse } = require("../../http");
+
+const cacheFolder = path.resolve(
+  process.env.STORAGE_DIR
+    ? path.resolve(process.env.STORAGE_DIR, "models", "aimlapi", "embeddings")
+    : path.resolve(__dirname, `../../../storage/models/aimlapi/embeddings`)
+);
 
 class AimlApiEmbedder {
   constructor() {
@@ -7,20 +20,63 @@ class AimlApiEmbedder {
     const { OpenAI: OpenAIApi } = require("openai");
     this.openai = new OpenAIApi({
       apiKey: process.env.AIML_API_KEY,
-      baseURL: "https://api.aimlapi.com/v1",
+      baseURL: AIMLAPI_BASE_URL,
       defaultHeaders: AIMLAPI_HEADERS,
     });
     this.model = process.env.EMBEDDING_MODEL_PREF || "text-embedding-ada-002";
+    if (!fs.existsSync(cacheFolder)) fs.mkdirSync(cacheFolder, { recursive: true });
+    this.cacheModelPath = path.resolve(cacheFolder, "models.json");
+    this.cacheAtPath = path.resolve(cacheFolder, ".cached_at");
     this.maxConcurrentChunks = 500;
     this.embeddingMaxChunkLength = maximumChunkLength();
+    this.log(`Initialized ${this.model}`);
+    this.#syncModels().catch((e) =>
+      this.log(`Failed to sync models: ${e.message}`)
+    );
+  }
+
+  log(text, ...args) {
+    console.log(`\x1b[36m[AimlApiEmbedder]\x1b[0m ${text}`, ...args);
+  }
+
+  #cacheIsStale() {
+    const MAX_STALE = 6.048e8; // 1 Week in MS
+    if (!fs.existsSync(this.cacheAtPath)) return true;
+    const now = Number(new Date());
+    const timestampMs = Number(fs.readFileSync(this.cacheAtPath));
+    return now - timestampMs > MAX_STALE;
+  }
+
+  async #syncModels() {
+    if (fs.existsSync(this.cacheModelPath) && !this.#cacheIsStale()) return false;
+    this.log("Model cache is not present or stale. Fetching from AimlApi API.");
+    await fetchAimlApiEmbeddingModels();
+    return;
+  }
+
+  models() {
+    if (!fs.existsSync(this.cacheModelPath)) return {};
+    return safeJsonParse(
+      fs.readFileSync(this.cacheModelPath, { encoding: "utf-8" }),
+      {}
+    );
+  }
+
+  async isValidEmbeddingModel(modelName = "") {
+    await this.#syncModels();
+    const availableModels = this.models();
+    return Object.prototype.hasOwnProperty.call(availableModels, modelName);
   }
 
   async embedTextInput(textInput) {
-    const result = await this.embedChunks(Array.isArray(textInput) ? textInput : [textInput]);
+    const result = await this.embedChunks(
+      Array.isArray(textInput) ? textInput : [textInput]
+    );
     return result?.[0] || [];
   }
 
   async embedChunks(textChunks = []) {
+    this.log(`Embedding ${textChunks.length} chunks...`);
     const embeddingRequests = [];
     for (const chunk of toChunks(textChunks, this.maxConcurrentChunks)) {
       embeddingRequests.push(
@@ -29,7 +85,10 @@ class AimlApiEmbedder {
             .create({ model: this.model, input: chunk })
             .then((result) => resolve({ data: result?.data, error: null }))
             .catch((e) => {
-              e.type = e?.response?.data?.error?.code || e?.response?.status || "failed_to_embed";
+              e.type =
+                e?.response?.data?.error?.code ||
+                e?.response?.status ||
+                "failed_to_embed";
               e.message = e?.response?.data?.error?.message || e.message;
               resolve({ data: [], error: e });
             });
@@ -37,8 +96,12 @@ class AimlApiEmbedder {
       );
     }
 
-    const { data = [], error = null } = await Promise.all(embeddingRequests).then((results) => {
-      const errors = results.filter((res) => !!res.error).map((res) => res.error);
+    const { data = [], error = null } = await Promise.all(
+      embeddingRequests
+    ).then((results) => {
+      const errors = results
+        .filter((res) => !!res.error)
+        .map((res) => res.error);
       if (errors.length > 0) {
         const unique = new Set();
         errors.forEach((err) => unique.add(`[${err.type}]: ${err.message}`));

--- a/server/utils/agents/aibitat/providers/aimlapi.js
+++ b/server/utils/agents/aibitat/providers/aimlapi.js
@@ -1,5 +1,8 @@
 const OpenAI = require("openai");
-const { AIMLAPI_HEADERS } = require("../../AiProviders/aimlapi");
+const {
+  AIMLAPI_HEADERS,
+  AIMLAPI_BASE_URL,
+} = require("../../AiProviders/aimlapi");
 const Provider = require("./ai-provider.js");
 const InheritMultiple = require("./helpers/classes.js");
 const UnTooled = require("./helpers/untooled.js");
@@ -11,7 +14,7 @@ class AimlApiProvider extends InheritMultiple([Provider, UnTooled]) {
     super();
     const { model = "gpt-3.5-turbo" } = config;
     const client = new OpenAI({
-      baseURL: "https://api.aimlapi.com/v1",
+      baseURL: AIMLAPI_BASE_URL,
       apiKey: process.env.AIML_API_KEY ?? null,
       maxRetries: 3,
       defaultHeaders: AIMLAPI_HEADERS,


### PR DESCRIPTION
## Summary
- unify AimlApi constants across LLM and embedding modules
- use shared base URL in agent provider
- add logging to AimlApi embedder
- sync AimlApi embedding models on init

## Testing
- `npm run lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6876c5b5c0408329882a4ff04e2488be